### PR TITLE
chore: add publishConfig to package.json for public access

### DIFF
--- a/packages/lib-one/package.json
+++ b/packages/lib-one/package.json
@@ -11,6 +11,9 @@
             "require": "./dist/index.js"
         }
     },
+    "publishConfig": {
+        "access": "public"
+    },
     "files": [
         "dist"
     ],

--- a/packages/lib-two/package.json
+++ b/packages/lib-two/package.json
@@ -11,6 +11,9 @@
             "require": "./dist/index.js"
         }
     },
+    "publishConfig": {
+        "access": "public"
+    },
     "files": [
         "dist"
     ],


### PR DESCRIPTION
This pull request updates the publish configuration for two library packages to ensure they are published as public packages on npm.

Package configuration updates:

* Added a `publishConfig` section with `"access": "public"` to `packages/lib-one/package.json` to specify that the package should be published publicly.
* Added a `publishConfig` section with `"access": "public"` to `packages/lib-two/package.json` to specify that the package should be published publicly.