### PR TITLE
feat: add event type logging and skip check for non-PR events in requ…

### DIFF
--- a/.github/actions/require-changeset/action.yaml
+++ b/.github/actions/require-changeset/action.yaml
@@ -6,8 +6,15 @@ runs:
     - name: Check for changeset in PR
       shell: bash
       run: |
+        echo "Event type: ${{ github.event_name }}"
         echo "PR title: ${{ github.event.pull_request.title }}"
         echo "Actor: ${{ github.actor }}"
+
+        # Skip if not a pull request
+        if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          echo "ℹ️ Not a pull request, skipping changeset check."
+          exit 0
+        fi
 
         # Skip guard for release PRs created by Changesets
         if [[ "${{ github.event.pull_request.title }}" == "Version Packages"* ]] \


### PR DESCRIPTION
This pull request adds a small improvement to the `.github/actions/require-changeset/action.yaml` workflow. The main change is a guard that checks the event type and skips the changeset check if the workflow is not triggered by a pull request. This helps prevent unnecessary steps for non-PR events.