### PR TITLE
docs: update CI/CD and CodeQL badges in README [skip changeset check]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # systemcraft/play-npmlib
 
-[![Build](https://github.com/deresegetachew/play-npmlib/workflows/main/badge.svg)](https://github.com/deresegetachew/play-npmlib/actions/workflows/main.yaml)
-[![CodeQL](https://github.com/deresegetachew/play-npmlib/workflows/CodeQLAnalyze/badge.svg)](https://github.com/deresegetachew/play-npmlib/actions/workflows/codeql.yml)
+[![CI/CD](https://github.com/deresegetachew/play-npmlib/workflows/main/badge.svg)](https://github.com/deresegetachew/play-npmlib/actions/workflows/main.yaml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/deresegetachew/play-npmlib/codeql.yml?label=CodeQL&logo=github)](https://github.com/deresegetachew/play-npmlib/actions/workflows/codeql.yml)
 [![GitHub release](https://img.shields.io/github/release/deresegetachew/play-npmlib.svg)](https://github.com/deresegetachew/play-npmlib/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
This pull request updates the badges in the `README.md` file to improve clarity and consistency in the display of build and CodeQL status.

Documentation updates:

* Changed the build badge label from "Build" to "CI/CD" for clearer representation.
* Updated the CodeQL badge to use the Shields.io format for improved appearance and consistency with other badges.